### PR TITLE
Allows for class inheritance

### DIFF
--- a/lib/interloper/version.rb
+++ b/lib/interloper/version.rb
@@ -1,3 +1,3 @@
 module Interloper
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Callbacks can be defined on a method from parent and child classes, and they
will be run in the expected order.

See spec/interloper_spec.rb for tests involving callbacks defined in parent and
child classes.

Bumps version to v0.1.4