### PR TITLE
Allows inheritance of callbacks

### DIFF
--- a/lib/interloper.rb
+++ b/lib/interloper.rb
@@ -114,5 +114,35 @@ module Interloper
       interloper_module.define_interloper_methods(*method_names, interloper_const_name)
       interloper_module.add_callbacks(:after, *method_names, &callback)
     end
+
+    def inherit_callbacks_for(*method_names)
+      inherit_callbacks_before(*method_names)
+      inherit_callbacks_after(*method_names)
+    end
+
+    def inherit_callbacks_before(*method_names)
+      inherited_callbacks(:before, *method_names).each do |callback|
+        before(*method_names, &callback)
+      end
+    end
+
+    def inherit_callbacks_after(*method_names)
+      inherited_callbacks(:after, *method_names).each do |callback|
+        after(*method_names, &callback)
+      end
+    end
+
+    def inherited_callbacks(hook, *method_names)
+      method_names.map do |method_name|
+        ancestor_interloper_module.callbacks[hook][method_name]
+      end.flatten
+    end
+
+    # @return [Module] The nearest ancstors tha is an interloper module.
+    def ancestor_interloper_module
+      ancestors.detect do |ancestor|
+         ancestor.respond_to?(:interloper_module) && (ancestor != self)
+      end.interloper_module
+    end
   end
 end

--- a/lib/interloper/version.rb
+++ b/lib/interloper/version.rb
@@ -1,3 +1,3 @@
 module Interloper
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
A child class can call .inherit_callbacks_before and .inherit_callbacks_after to
use the nearest ancestor's callbacks as their own. This can be useful when you
want to run callbacks defined in an ancestor class when the subclass's method is
called

Note that calling 'super' from an overridden instance method for which callbacks
have inherited from an ancestor, will continue to call the parent's callbacks
immediately before and/or after the call to 'super'.

Bumps to verion v0.2.0